### PR TITLE
Fixed styles of pool margin summary

### DIFF
--- a/app/pool_margin/pool.margin.latest.summary.component.scss
+++ b/app/pool_margin/pool.margin.latest.summary.component.scss
@@ -24,7 +24,7 @@
     }
 
     .mat-card {
-        @include flex(1, 1, 200px);
+        @include flex(2, 1, 200px);
 
         @include display-flex();
         @include flex-direction(column);
@@ -44,7 +44,7 @@
     }
 
     .poolName {
-        @include flex(1 1 1%);
+        @include flex(1 1 auto);
     }
 
     .poolDetail {


### PR DESCRIPTION
In IE 11 the flexbox is incorrectly computed:
![image](https://user-images.githubusercontent.com/209500/30210438-fa530484-949c-11e7-93ca-22b6639d3795.png)
